### PR TITLE
Addition of timing specifications available for groups

### DIFF
--- a/tutorials/groups.md
+++ b/tutorials/groups.md
@@ -249,3 +249,18 @@ Syntax:
 handleVoteResult(group, rfvId, vote)
   where vote = true or false
 ```
+
+### Additional Group Parameters
+
+Users can optionally overwrite some of the default timeout values by specifying them while defining the group in the application model. Here is an example of a group with a leader and user specified parameters:
+
+```
+group TheGroup with leader using Msg
+heartbeat = 2000, electionMin = 2500, electionMax = 3000, peerTimeout = 3500, consensusTimeout = 2500;
+```
+
+The various parameters available are:
+- `heartbeat`: Group heartbeat period. Default is 1000.
+- `electionMin` and `electionMax`: The election timeout is the maximum time a follower waits until it becomes a candidate (see "Leader Elections" section). The value will be randomly selected between these two values. Default is 1500 and 2000 respectively.
+- `peerTimeout`: A peer is declared lost after this timeout. This value must be less than the `electionMax`. Default is 3000.
+- `consensusTimeout`: Maximum time to get the result of a consensus vote (see "Consensus Voting" section"). Default is 1500.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Document update


**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**
Added group timing parameters to tutorial on groups


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
